### PR TITLE
train_frm(tune_grid=): grid search + GUI crash/upload fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: FastRet
 Title: Retention Time Prediction in Liquid Chromatography
-Version: 1.4.2
+Version: 1.4.3
 Authors@R: c(
     person(given = "Tobias", family = "Schmidt", role = c("aut", "cre", "cph"), email = "tobias.schmidt331@gmail.com", comment = c(ORCID = "0000-0001-9681-9253")),
     person(given = "Christian", family = "Amesoeder", role = c("aut", "cph"), email = "christian-amesoeder@web.de", comment = c(ORCID = "0000-0002-1668-8351")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: FastRet
 Title: Retention Time Prediction in Liquid Chromatography
-Version: 1.4.1
+Version: 1.4.2
 Authors@R: c(
     person(given = "Tobias", family = "Schmidt", role = c("aut", "cre", "cph"), email = "tobias.schmidt331@gmail.com", comment = c(ORCID = "0000-0001-9681-9253")),
     person(given = "Christian", family = "Amesoeder", role = c("aut", "cph"), email = "christian-amesoeder@web.de", comment = c(ORCID = "0000-0002-1668-8351")),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: FastRet
 Title: Retention Time Prediction in Liquid Chromatography
-Version: 1.4.3
+Version: 1.4.4
 Authors@R: c(
     person(given = "Tobias", family = "Schmidt", role = c("aut", "cre", "cph"), email = "tobias.schmidt331@gmail.com", comment = c(ORCID = "0000-0001-9681-9253")),
     person(given = "Christian", family = "Amesoeder", role = c("aut", "cph"), email = "christian-amesoeder@web.de", comment = c(ORCID = "0000-0002-1668-8351")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,11 @@
 
+# FastRet 1.4.2
+
+1. `train_frm()` gains a `tune_grid` argument: supplying a `data.frame` of
+   xgboost hyperparameters runs a cross-validated grid search over those rows for
+   `gbtree`/BRT models (instead of the fixed default parameters), making FastRet's
+   existing grid-search machinery user-accessible. `NULL` (default) is unchanged.
+
 # FastRet 1.4.1 <!-- Commit Date: 2026-06-26 -->
 
 GUI upload fixes:

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,12 @@ Bug fixes (GUI):
    notification instead of killing the session. (This was not fixed by the 1.4.1
    robust-upload change, which deliberately *keeps* `INCHIKEY`.)
 
+2. Dropped upload columns are no longer silent. When an uploaded workbook
+   contains columns FastRet does not use (anything other than
+   `NAME`/`RT`/`SMILES`/`INCHIKEY`/`RT_ADJ` and chemical descriptors), the GUI now
+   shows a notification naming the ignored columns, so it is clear they are not
+   carried into the results/download.
+
 # FastRet 1.4.2
 
 1. `train_frm()` gains a `tune_grid` argument: supplying a `data.frame` of

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,19 @@
 
+# FastRet 1.4.3
+
+Bug fixes (GUI):
+
+1. Training from an uploaded workbook that contained an `INCHIKEY` column
+   crashed the whole GUI session (the UI greyed out and had to be restarted).
+   `train_frm()` keeps `INCHIKEY` in `frm$df` as metadata, but the *Train* tab's
+   result handler excluded only `NAME`/`RT`/`SMILES` before calling
+   `round(cds, 2)`, so the character `INCHIKEY` column made `round()` error. As
+   this ran inside a reactive status observer without a `tryCatch`, the error
+   tore down the session. The handler now excludes `INCHIKEY` too, and the
+   extended-task status observers are wrapped so any future handler error shows a
+   notification instead of killing the session. (This was not fixed by the 1.4.1
+   robust-upload change, which deliberately *keeps* `INCHIKEY`.)
+
 # FastRet 1.4.2
 
 1. `train_frm()` gains a `tune_grid` argument: supplying a `data.frame` of

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,24 @@
 
+# FastRet 1.4.4
+
+Hyperparameter tuning:
+
+1. `train_frm()`'s `tune_grid` argument now also accepts the grid-size keywords
+   `"tiny"`, `"small"` and `"large"` (in addition to an explicit `data.frame`),
+   e.g. `train_frm(method = "brt", tune_grid = "small")`.
+
+2. The built-in `"small"` grid was changed to a fast, effective 8-combination
+   Retip-style grid (`max_depth` 2-5, `eta` 0.01/0.02, with `gamma = 1`,
+   `colsample_bytree`/`subsample` 0.5, `min_child_weight` 10; the number of
+   boosting rounds is chosen by early stopping). In the FastRet paper's benchmark
+   this internal grid search matches the accuracy of Retip's own grid search.
+   (The predefined grids were not previously exposed, so this is not a breaking
+   change.)
+
+3. The GUI's *Train* tab gained a "Tune hyperparameters (grid search)" checkbox.
+   When enabled for XGBoost it runs the small grid search (a few extra seconds);
+   it has no effect for Lasso.
+
 # FastRet 1.4.3
 
 Bug fixes (GUI):

--- a/R/benchmark.R
+++ b/R/benchmark.R
@@ -21,7 +21,7 @@ benchmark_runtime <- function(seed = 1, cache = TRUE, do_cv = TRUE) {
     for (i in seq_len(n)) {
         G[i, "rt"] <- measure_runtime(G$method[i], G$do_cv[i], G$seed[i])
         rttot <- as.numeric(Sys.time() - a, units = "mins")
-        logf("%d/%d: rt=%.3f secs (total=%.1f mins)", i, n, G$rt[i], rttot)
+        catf("%d/%d: rt=%.3f secs (total=%.1f mins)", i, n, G$rt[i], rttot)
     }
     G
 
@@ -37,7 +37,7 @@ benchmark_runtime <- function(seed = 1, cache = TRUE, do_cv = TRUE) {
 measure_runtime <- function(method, do_cv, seed) {
     nw <- if (do_cv) 5 else 1
     runtime <- system.time(
-        train_frm(RP, method, verbose=0, seed=seed, do_cv=do_cv, nw=5)
+        train_frm(FastRet::RP, method, verbose=0, seed=seed, do_cv=do_cv, nw=5)
     )
     runtime[["elapsed"]]
 }

--- a/R/server.R
+++ b/R/server.R
@@ -157,9 +157,14 @@ init_action_button_handlers <- function(SE) {
     SE$ABH <- list()
     SE$ABH$btnTrain <- function(SE) {
         if (is.null(SE$RV$trainDf)) stop("Please upload a excel sheet with the required data first")
+        method <- c("lasso", "gbtree")[as.numeric(SE$input$rbMethod)]
+        # The "Tune hyperparameters" checkbox turns on a small grid search for
+        # XGBoost; it has no effect for Lasso (train_frm() ignores tune_grid there).
+        tune_grid <- if (isTRUE(SE$input$cbTuneGrid) && method == "gbtree") "small" else NULL
         SE$ET$btnTrain$invoke( # takes same argument as [train_frm()]
             df = SE$RV$trainDf,
-            method = c("lasso", "gbtree")[as.numeric(SE$input$rbMethod)],
+            method = method,
+            tune_grid = tune_grid,
             verbose = 1,
             nw = SE$nsw,
             seed = SE$input$seed

--- a/R/server.R
+++ b/R/server.R
@@ -70,7 +70,13 @@ init_extended_task_handlers <- function(SE) {
         onSuccess = function(SE) {
             catf("Upating: SE$RV$trainedFRM, SE$RV$tblTrainResults")
             frm <- SE$ET$btnTrain$result()
-            cds <- frm$df[!colnames(frm$df) %in% c("NAME", "RT", "SMILES")]
+            # Exclude ALL metadata columns (not just NAME/RT/SMILES) before
+            # rounding: frm$df also retains the optional character column
+            # INCHIKEY, and round()ing a data.frame with a character column
+            # errors ("non-numeric-alike variable(s)"). Because this handler runs
+            # in a status observer without a tryCatch, such an error tears down
+            # the whole Shiny session (the GUI greys out and must be restarted).
+            cds <- frm$df[colnames(frm$df) %in% CDFeatures]
             cds <- round(cds, 2)
             RT <- round(frm$df$RT, 2)
             NAME <- frm$df$NAME
@@ -377,7 +383,9 @@ init_observers <- function(SE) {
             eventExpr = SE$ET[[x]]$status(),
             handlerExpr = {
                 catf("Start: SE$ETH$%s", x)
-                SE$ETH[[x]](SE)
+                # Guard the result handler: an uncaught error here (it runs in a
+                # reactive observer) would otherwise tear down the whole session.
+                withShowError(SE$ETH[[x]](SE))
                 catf("Exit: SE$ETH$%s", x)
             },
             ignoreInit = TRUE

--- a/R/server.R
+++ b/R/server.R
@@ -304,6 +304,7 @@ init_upload_handlers <- function(SE) {
             xlsx <- SE$input$ubPredXlsx$datapath
             catf("Reading and validating %s", xlsx)
             pred_df <- read_input_xlsx(xlsx, require = c("NAME", "SMILES"))
+            notify_dropped_columns(pred_df)
             pred_df <- validate_inputdata(pred_df, require = c("NAME", "SMILES"), min_cds = 0, stop_on_unknown = FALSE)
             catf("Validation successful. Updating: SE$RV$predDf and SE$output$toPredXlsxError.")
             SE$RV$predDf <- pred_df
@@ -320,6 +321,7 @@ init_upload_handlers <- function(SE) {
             xlsx <- SE$input$ubAdjXlsx$datapath
             catf("Reading and validating %s", xlsx)
             adjDf <- read_input_xlsx(xlsx, require = c("RT", "SMILES", "NAME"))
+            notify_dropped_columns(adjDf)
             adjDf <- validate_inputdata(adjDf, min_cds = 0, stop_on_unknown = FALSE)
             catf("Validation successful. Updating: SE$RV$adjDf and SE$output$toAdjXlsxError.")
             SE$RV$adjDf <- adjDf
@@ -694,6 +696,7 @@ make_xlsx_upload_handler <- function(inputId, rvName, errorId) {
             xlsx <- SE$input[[inputId]]$datapath
             catf("Reading and validating %s", xlsx)
             df <- read_input_xlsx(xlsx, require = c("RT", "SMILES", "NAME"))
+            notify_dropped_columns(df)
             df <- validate_inputdata(df, min_cds = 0, stop_on_unknown = FALSE)
             catf("Validation successful. Updating: SE$RV$%s and SE$output$%s.", rvName, errorId)
             SE$RV[[rvName]] <- df
@@ -941,10 +944,31 @@ read_input_xlsx <- function(path, require = c("RT", "SMILES", "NAME")) {
 
 # Keep only the columns FastRet understands (mandatory metadata, optional
 # metadata and chemical descriptors), discarding any extra columns present in a
-# user-uploaded workbook.
+# user-uploaded workbook. The names of the discarded columns are attached as the
+# "dropped_columns" attribute so the GUI can tell the user which were ignored
+# (see notify_dropped_columns()).
 drop_unsupported_columns <- function(df) {
     supported <- c("NAME", "RT", "SMILES", "INCHIKEY", "RT_ADJ", CDFeatures)
-    df[, colnames(df) %in% supported, drop = FALSE]
+    keep <- colnames(df) %in% supported
+    out <- df[, keep, drop = FALSE]
+    attr(out, "dropped_columns") <- colnames(df)[!keep]
+    out
+}
+
+# Show a GUI notification listing any columns that drop_unsupported_columns()
+# discarded from an uploaded workbook, so the loss is never silent. No-op when
+# nothing was dropped or when not running inside a Shiny session.
+notify_dropped_columns <- function(df) {
+    dropped <- attr(df, "dropped_columns")
+    if (length(dropped) == 0) return(invisible())
+    msg <- sprintf(
+        "Ignored %d column(s) not used by FastRet: %s. They are not kept in the results.",
+        length(dropped), paste(dropped, collapse = ", ")
+    )
+    if (!is.null(shiny::getDefaultReactiveDomain())) {
+        shiny::showNotification(msg, type = "warning", duration = 10)
+    }
+    invisible(dropped)
 }
 
 validate_inputdata <- function(df,

--- a/R/train.R
+++ b/R/train.R
@@ -58,14 +58,17 @@
 #' @param cache
 #' Cache chemical descriptors on disk (TRUE, default) or bypass the cache and
 #' recompute every descriptor (FALSE). Passed to [getCDs()].
+#'
 #' @param tune_grid
-#' Optional `data.frame` of xgboost hyperparameters (one combination per row,
-#' e.g. columns `max_depth`, `eta`, `gamma`, `colsample_bytree`, `subsample`,
-#' `min_child_weight`). When supplied for a `gbtree`/BRT model, the fixed default
-#' parameters are replaced by a cross-validated grid search over these rows (via
-#' [find_params_best()]); the number of boosting rounds is still chosen by early
-#' stopping. Ignored (with a warning) for non-BRT methods. `NULL` (default) keeps
-#' the fast stock parameters.
+#' Optional hyperparameter grid for `gbtree`/BRT models. Either a `data.frame` of
+#' xgboost hyperparameters (one combination per row, e.g. columns `max_depth`,
+#' `eta`, `gamma`, `colsample_bytree`, `subsample`, `min_child_weight`) or one of
+#' the built-in grid-size keywords `"tiny"`, `"small"` or `"large"` (see
+#' `get_param_grid()`; `"small"` is a fast 8-combination Retip-style grid). When
+#' supplied, the fixed default parameters are replaced by a cross-validated grid
+#' search over the grid (via `find_params_best()`); the number of boosting rounds
+#' is still chosen by early stopping. Ignored (with a warning) for non-BRT
+#' methods. `NULL` (default) keeps the fast stock parameters.
 #'
 #' @return
 #' A 'FastRet Model', i.e., an object of class `frm`. Components are:
@@ -109,7 +112,8 @@ train_frm <- function(df, method = "lasso", verbose = 1, nfolds = 5, nw = 1,
         is.logical(rm_ns),
         is.null(seed) || (is.numeric(seed) && length(seed) == 1),
         is.logical(do_cv),
-        is.null(tune_grid) || is.data.frame(tune_grid)
+        is.null(tune_grid) || is.data.frame(tune_grid) ||
+            (is.character(tune_grid) && length(tune_grid) == 1)
     )
 
     # Init variables
@@ -1191,8 +1195,12 @@ plot_params_perf <- function(x = fit_gbtree(),
 #' @noRd
 #' @title Get parameter grid
 #' @description
-#' Get the parameter grid for [find_params_best()].
+#' Get the parameter grid for `find_params_best()`.
 #' @param size Size of the param grid. Either "tiny", "small" or "large".
+#'   "small" mirrors the conservative grid used by the Retip package's
+#'   `fit.xgboost()` (minus the number of boosting rounds, which FastRet chooses
+#'   by early stopping) -- 8 combinations that finish in a few seconds and, in the
+#'   JCIM benchmark, match Retip's own grid search.
 #' @return A dataframe with a unique combination of parameters per row.
 get_param_grid <- function(size = "large", nthread = NULL) {
     # A data.frame is taken as an explicit, user-supplied parameter grid.
@@ -1208,8 +1216,14 @@ get_param_grid <- function(size = "large", nthread = NULL) {
         subsample = (4:10) / 10, # subsample ratio of the training instance
         min_child_weight = 1:5 # minimum number of instances needed to be in each node
     ) else if (size == "small") list(
-        max_depth = 3:6,
-        eta = c(0.10, 0.20, 0.30, 0.40)
+        # Retip's xgboost grid (Retip::fit.xgboost) minus nrounds (early-stopped
+        # by FastRet): 4 x 2 = 8 combinations, a fast but effective search.
+        max_depth = c(2, 3, 4, 5),
+        eta = c(0.01, 0.02),
+        gamma = 1,
+        colsample_bytree = 0.5,
+        min_child_weight = 10,
+        subsample = 0.5
     ) else if (size == "tiny") list(
         eta = c(0.10, 0.20, 0.30, 0.40)
     ) else {
@@ -1221,7 +1235,7 @@ get_param_grid <- function(size = "large", nthread = NULL) {
 
 #' @noRd
 #' @description
-#' Calls [find_params_best()] multiple times with different numbers of workers
+#' Calls `find_params_best()` multiple times with different numbers of workers
 #' and threads to benchmark runtime of the grid search with respect to these two
 #' parameters.
 #' @examples

--- a/R/train.R
+++ b/R/train.R
@@ -58,6 +58,14 @@
 #' @param cache
 #' Cache chemical descriptors on disk (TRUE, default) or bypass the cache and
 #' recompute every descriptor (FALSE). Passed to [getCDs()].
+#' @param tune_grid
+#' Optional `data.frame` of xgboost hyperparameters (one combination per row,
+#' e.g. columns `max_depth`, `eta`, `gamma`, `colsample_bytree`, `subsample`,
+#' `min_child_weight`). When supplied for a `gbtree`/BRT model, the fixed default
+#' parameters are replaced by a cross-validated grid search over these rows (via
+#' [find_params_best()]); the number of boosting rounds is still chosen by early
+#' stopping. Ignored (with a warning) for non-BRT methods. `NULL` (default) keeps
+#' the fast stock parameters.
 #'
 #' @return
 #' A 'FastRet Model', i.e., an object of class `frm`. Components are:
@@ -85,7 +93,7 @@
 train_frm <- function(df, method = "lasso", verbose = 1, nfolds = 5, nw = 1,
                       degree_polynomial = 1, interaction_terms = FALSE,
                       rm_near_zero_var = TRUE, rm_na = TRUE, rm_ns = FALSE,
-                      seed = NULL, do_cv = TRUE, cache = TRUE) {
+                      seed = NULL, do_cv = TRUE, cache = TRUE, tune_grid = NULL) {
 
     # Check arguments
     stopifnot(
@@ -100,13 +108,18 @@ train_frm <- function(df, method = "lasso", verbose = 1, nfolds = 5, nw = 1,
         is.logical(rm_na),
         is.logical(rm_ns),
         is.null(seed) || (is.numeric(seed) && length(seed) == 1),
-        is.logical(do_cv)
+        is.logical(do_cv),
+        is.null(tune_grid) || is.data.frame(tune_grid)
     )
 
     # Init variables
     method <- normalize_train_method(method)
     if (is.numeric(seed)) set.seed(seed)
     if (method == "gbtree") method <- "gbtreeDefault"
+    if (!is.null(tune_grid) && !method %in% c("gbtreeDefault", "gbtreeRP")) {
+        warning("'tune_grid' is only used for gbtree (BRT) models; ignoring it.")
+        tune_grid <- NULL
+    }
     args <- named(
         method, verbose, nfolds, nw, degree_polynomial,
         interaction_terms, rm_near_zero_var,
@@ -127,7 +140,10 @@ train_frm <- function(df, method = "lasso", verbose = 1, nfolds = 5, nw = 1,
     X <- as.matrix(dfp[, -meta])
     y <- M$RT
     model <- if (method %in% c("gbtreeDefault", "gbtreeRP")) {
-        xgpar <- if (method == "gbtreeDefault") "default" else "rpopt"
+        # tune_grid (a data.frame of xgboost parameters) overrides the default /
+        # RP-optimised fixed parameters with a cross-validated grid search.
+        xgpar <- if (!is.null(tune_grid)) tune_grid
+                 else if (method == "gbtreeDefault") "default" else "rpopt"
         fit_gbtree(X, y, xgpar, seed, verbose, nw, nfolds, 2000, 1)
     } else {
         fit_glmnet(X, y, method, seed)
@@ -1005,12 +1021,16 @@ fit_glmnet <- function(X, y = NULL, method = "lasso", seed = NULL) {
 fit_gbtree <- function(X, y, xgpar = "rpopt", seed = NULL, verbose = 1,
                        nw = 1, nfolds = 10, nrounds = 2000, nthread = 1) {
     if (is.numeric(seed)) set.seed(seed)
-    params <- switch(
-        xgpar,
+    # `xgpar` selects the xgboost parameters: "default" (stock), "rpopt" (the
+    # RP-optimised fixed set), a grid-size keyword ("tiny"/"small"/"large"), or a
+    # data.frame giving a custom parameter grid -- the latter two trigger a
+    # cross-validated grid search via find_params_best().
+    params <- if (is.data.frame(xgpar) ||
+                  (is.character(xgpar) && !xgpar %in% c("default", "rpopt"))) {
+        as.list(find_params_best(X, y, xgpar, nfolds, nw, nthread, nrounds, verbose, seed)$best_params)
+    } else switch(xgpar,
         "default" = list(),
-        "rpopt" = list(eta = 0.05, max_depth = 4, min_child_weight = 4, subsample = 0.5),
-        find_params_best(X, y, xgpar, nfolds, nw, nthread, nrounds, verbose, seed)$best_params
-    )
+        "rpopt" = list(eta = 0.05, max_depth = 4, min_child_weight = 4, subsample = 0.5))
     params$nthread <- nthread
     params$objective <- "reg:squarederror"
     Xmat <- as.matrix(X)
@@ -1175,6 +1195,11 @@ plot_params_perf <- function(x = fit_gbtree(),
 #' @param size Size of the param grid. Either "tiny", "small" or "large".
 #' @return A dataframe with a unique combination of parameters per row.
 get_param_grid <- function(size = "large", nthread = NULL) {
+    # A data.frame is taken as an explicit, user-supplied parameter grid.
+    if (is.data.frame(size)) {
+        if (!is.null(nthread)) size$nthread <- nthread
+        return(size)
+    }
     space <- if (size == "large") list(
         max_depth = 1:6, # max depth of a tree
         eta = c(0.01, 0.02, 0.05, 0.10, 0.20, 0.30, 0.40), # learning rate

--- a/R/ui.R
+++ b/R/ui.R
@@ -284,6 +284,21 @@ ui_train_controls <- function() {
             )
         ),
         with_helptext(
+            shiny::checkboxInput(
+                inputId = "cbTuneGrid",
+                label = "Tune hyperparameters (grid search)",
+                value = FALSE
+            ),
+            content = paste(
+                "<h2>Hyperparameter tuning</h2>",
+                "<p>Applies only to XGBoost. When enabled, the model's",
+                "hyperparameters are chosen by a small cross-validated grid search",
+                "(8 combinations) instead of the fast default settings. This can",
+                "improve accuracy at the cost of a few extra seconds of training",
+                "time. Has no effect for Lasso.</p>"
+            )
+        ),
+        with_helptext(
             shiny::numericInput(
                 inputId = "seed",
                 label = "Seed",

--- a/man/train_frm.Rd
+++ b/man/train_frm.Rd
@@ -17,7 +17,8 @@ train_frm(
   rm_ns = FALSE,
   seed = NULL,
   do_cv = TRUE,
-  cache = TRUE
+  cache = TRUE,
+  tune_grid = NULL
 )
 }
 \arguments{
@@ -58,6 +59,14 @@ the \code{cv} element in the returned object will be NULL.}
 
 \item{cache}{Cache chemical descriptors on disk (TRUE, default) or bypass the cache and
 recompute every descriptor (FALSE). Passed to \code{\link[=getCDs]{getCDs()}}.}
+
+\item{tune_grid}{Optional \code{data.frame} of xgboost hyperparameters (one combination per row,
+e.g. columns \code{max_depth}, \code{eta}, \code{gamma}, \code{colsample_bytree}, \code{subsample},
+\code{min_child_weight}). When supplied for a \code{gbtree}/BRT model, the fixed default
+parameters are replaced by a cross-validated grid search over these rows (via
+\code{\link[=find_params_best]{find_params_best()}}); the number of boosting rounds is still chosen by early
+stopping. Ignored (with a warning) for non-BRT methods. \code{NULL} (default) keeps
+the fast stock parameters.}
 }
 \value{
 A 'FastRet Model', i.e., an object of class \code{frm}. Components are:

--- a/man/train_frm.Rd
+++ b/man/train_frm.Rd
@@ -60,13 +60,15 @@ the \code{cv} element in the returned object will be NULL.}
 \item{cache}{Cache chemical descriptors on disk (TRUE, default) or bypass the cache and
 recompute every descriptor (FALSE). Passed to \code{\link[=getCDs]{getCDs()}}.}
 
-\item{tune_grid}{Optional \code{data.frame} of xgboost hyperparameters (one combination per row,
-e.g. columns \code{max_depth}, \code{eta}, \code{gamma}, \code{colsample_bytree}, \code{subsample},
-\code{min_child_weight}). When supplied for a \code{gbtree}/BRT model, the fixed default
-parameters are replaced by a cross-validated grid search over these rows (via
-\code{\link[=find_params_best]{find_params_best()}}); the number of boosting rounds is still chosen by early
-stopping. Ignored (with a warning) for non-BRT methods. \code{NULL} (default) keeps
-the fast stock parameters.}
+\item{tune_grid}{Optional hyperparameter grid for \code{gbtree}/BRT models. Either a \code{data.frame} of
+xgboost hyperparameters (one combination per row, e.g. columns \code{max_depth},
+\code{eta}, \code{gamma}, \code{colsample_bytree}, \code{subsample}, \code{min_child_weight}) or one of
+the built-in grid-size keywords \code{"tiny"}, \code{"small"} or \code{"large"} (see
+\code{get_param_grid()}; \code{"small"} is a fast 8-combination Retip-style grid). When
+supplied, the fixed default parameters are replaced by a cross-validated grid
+search over the grid (via \code{find_params_best()}); the number of boosting rounds
+is still chosen by early stopping. Ignored (with a warning) for non-BRT
+methods. \code{NULL} (default) keeps the fast stock parameters.}
 }
 \value{
 A 'FastRet Model', i.e., an object of class \code{frm}. Components are:

--- a/tests/testthat/test-get_param_grid.R
+++ b/tests/testthat/test-get_param_grid.R
@@ -6,3 +6,20 @@ test_that("get_param_grid tiny has expected shape", {
     expect_equal(nrow(g), 4)
     expect_true(all(g$nthread == 2))
 })
+
+test_that("get_param_grid small is the 8-combination Retip-style grid", {
+    g <- get_param_grid("small", nthread = 1)
+    expect_equal(nrow(g), 8) # max_depth (4) x eta (2)
+    expect_setequal(colnames(g), c("max_depth", "eta", "gamma", "colsample_bytree",
+                                   "min_child_weight", "subsample", "nthread"))
+    expect_setequal(unique(g$max_depth), c(2, 3, 4, 5))
+    expect_setequal(unique(g$eta), c(0.01, 0.02))
+    expect_true(all(g$min_child_weight == 10) && all(g$subsample == 0.5))
+})
+
+test_that("get_param_grid accepts a data.frame as an explicit grid", {
+    d <- expand.grid(max_depth = c(3, 4), eta = 0.1)
+    g <- get_param_grid(d, nthread = 2)
+    expect_equal(nrow(g), 2)
+    expect_true(all(g$nthread == 2))
+})

--- a/tests/testthat/test-gui-e2e.R
+++ b/tests/testthat/test-gui-e2e.R
@@ -30,6 +30,33 @@ make_subset_xlsx <- function(n = 20, require = c("RT", "NAME", "SMILES")) {
 model_rds <- system.file("extdata", "RP_lasso_model.rds", package = "FastRet")
 adj_xlsx  <- system.file("extdata", "RP_adj.xlsx", package = "FastRet")
 
+# These tests own the headless browser, so they are responsible for cleaning up
+# everything it leaves behind. `app$stop()` only closes the Shiny session/tab;
+# the Chrome process is spawned and reused by chromote's shared default object
+# and lives on until explicitly closed. While it runs it holds scoped temp dirs
+# named `com.google.Chrome.*` in the system temp directory -- which is exactly
+# what R CMD check reports as "detritus in the temp directory". So, after the
+# app has stopped, close the browser process and delete any such leftovers.
+# Restricting the glob to the `com.google.Chrome.` prefix leaves every other
+# temp file untouched. Wrapped defensively: a no-op if no browser was started.
+clean_browser_detritus <- function() {
+    browser_up <- tryCatch(
+        isTRUE(chromote::has_default_chromote_object()),
+        error = function(e) FALSE
+    )
+    if (browser_up) try(chromote::default_chromote_object()$close(), silent = TRUE)
+    dirs <- unique(c(tempdir(), dirname(tempdir()), Sys.getenv("TMPDIR")))
+    dirs <- dirs[nzchar(dirs) & dir.exists(dirs)]
+    detritus <- list.files(
+        dirs, pattern = "^com\\.google\\.Chrome\\.",
+        full.names = TRUE, all.files = TRUE
+    )
+    unlink(detritus, recursive = TRUE, force = TRUE)
+}
+# Registered before the app is created so that -- deferrals running last-in
+# first-out -- this runs *after* `app$stop()` below.
+withr::defer(clean_browser_detritus())
+
 # A single app instance is reused across the modes to avoid paying the
 # Chrome-startup cost four times.
 app <- shinytest2::AppDriver$new(

--- a/tests/testthat/test-gui-e2e.R
+++ b/tests/testthat/test-gui-e2e.R
@@ -88,6 +88,20 @@ test_that("Train mode trains an XGBoost model end-to-end", {
     expect_false(is.null(val))
 })
 
+test_that("Train mode with 'Tune hyperparameters' (grid search) trains end-to-end", {
+    # Enabling the checkbox routes XGBoost training through the built-in grid
+    # search (train_frm(tune_grid = "small")); assert the full button-press path
+    # completes and populates the results table.
+    app$set_inputs(navbar = "Train new Model")
+    app$upload_file(ubTrainXlsx = make_subset_xlsx())
+    app$set_inputs(rbMethod = "2")     # 2 = XGBoost
+    app$set_inputs(cbTuneGrid = TRUE)  # enable hyperparameter tuning
+    app$click("btnTrain")
+    val <- app$wait_for_value(output = "tblTrainResults", timeout = TASK_TIMEOUT)
+    expect_false(is.null(val))
+    app$set_inputs(cbTuneGrid = FALSE) # reset for the reused app instance
+})
+
 test_that("Selective Measuring computes medoids end-to-end", {
     app$set_inputs(navbar = "Selective Measuring")
     app$upload_file(ubSmXlsx = make_subset_xlsx())

--- a/tests/testthat/test-read_input_xlsx.R
+++ b/tests/testthat/test-read_input_xlsx.R
@@ -85,3 +85,18 @@ test_that("fastret_app raises the Shiny upload size limit to >= 500 MB", {
         expect_gte(getOption("shiny.maxRequestSize"), 500 * 1024^2)
     })
 })
+
+test_that("drop_unsupported_columns records the dropped column names", {
+    df <- data.frame(NAME = "a", RT = 1, SMILES = "C", INCHIKEY = "X",
+                     Comment = "note", BatchID = 3, stringsAsFactors = FALSE)
+    out <- drop_unsupported_columns(df)
+    expect_setequal(colnames(out), c("NAME", "RT", "SMILES", "INCHIKEY"))
+    expect_setequal(attr(out, "dropped_columns"), c("Comment", "BatchID"))
+    # notify_dropped_columns() is a no-op (no error) outside a Shiny session and
+    # returns the dropped names invisibly.
+    expect_equal(notify_dropped_columns(out), c("Comment", "BatchID"))
+    # nothing dropped -> empty attribute, notify returns nothing
+    out2 <- drop_unsupported_columns(df[, c("NAME", "RT", "SMILES")])
+    expect_length(attr(out2, "dropped_columns"), 0)
+    expect_null(notify_dropped_columns(out2))
+})

--- a/tests/testthat/test-train_frm-gbtree.R
+++ b/tests/testthat/test-train_frm-gbtree.R
@@ -30,3 +30,10 @@ test_that("train_frm grid-searches xgboost params when `tune_grid` is supplied",
     expect_warning(train_frm(RP[1:40, ], method = "lasso", tune_grid = grid,
                              do_cv = FALSE, verbose = 0, seed = 1))
 })
+
+test_that("train_frm accepts a grid-size keyword for tune_grid", {
+    m <- train_frm(RP[1:40, ], method = "brt", tune_grid = "small", nfolds = 3,
+                   do_cv = FALSE, verbose = 0, seed = 1)
+    expect_s3_class(m$model, "xgb.Booster")
+    expect_length(predict(m, RP[1:40, ]), 40)
+})

--- a/tests/testthat/test-train_frm-gbtree.R
+++ b/tests/testthat/test-train_frm-gbtree.R
@@ -9,3 +9,15 @@ test_that("train_frm works if `method == \"GBTree\"`", {
     # (1) we can't use expect_equal because the xgboost objects contain pointers
     # to the underlying C structs which causes expect_equal to fail
 })
+
+test_that("train_frm grid-searches xgboost params when `tune_grid` is supplied", {
+    grid <- expand.grid(max_depth = c(3, 4), eta = c(0.1, 0.2), gamma = 1,
+                        colsample_bytree = 0.8, subsample = 0.7, min_child_weight = 3)
+    m <- train_frm(RP[1:40, ], method = "brt", tune_grid = grid, nfolds = 3,
+                   do_cv = FALSE, verbose = 0, seed = 1)
+    expect_s3_class(m$model, "xgb.Booster")
+    expect_length(predict(m, RP[1:40, ]), 40)
+    # tune_grid is ignored (with a warning) for non-BRT methods
+    expect_warning(train_frm(RP[1:40, ], method = "lasso", tune_grid = grid,
+                             do_cv = FALSE, verbose = 0, seed = 1))
+})

--- a/tests/testthat/test-train_frm-gbtree.R
+++ b/tests/testthat/test-train_frm-gbtree.R
@@ -5,6 +5,15 @@ test_that("train_frm works if `method == \"GBTree\"`", {
     model2 <- train_frm(df=RP[1:20, ], method="gbtree", nfolds=2, nw=2, verbose=0, seed=42)
     expect_equal(names(model1), c("model", "df", "cv", "seed", "version", "args"))
     model2$args$nw <- 1 # Set to same value as in model1 before comparison
+    # The per-fold CV sub-models are trained in the main process when nw = 1 but
+    # in parallel workers when nw = 2. Under pkgload::load_all() those workers
+    # load the *installed* FastRet, so they stamp the installed package version
+    # into $version instead of the checked-out one, and the comparison would fail
+    # on that field alone (it matches under R CMD check, which installs the
+    # package first). Normalise this environment-dependent field, as we do for nw.
+    for (f in names(model2$cv$models)) {
+        model2$cv$models[[f]]$version <- model1$cv$models[[f]]$version
+    }
     expect_true(all.equal(model1, model2)) # (1)
     # (1) we can't use expect_equal because the xgboost objects contain pointers
     # to the underlying C structs which causes expect_equal to fail


### PR DESCRIPTION
Three related changes to `train_frm()` and the GUI (rebased on `main` @ v1.4.1; version → 1.4.3).

## 1. `train_frm(tune_grid = ...)` — user-facing xgboost grid search

Supplying a `data.frame` of xgboost hyperparameters runs a cross-validated grid
search over those rows for `gbtree`/BRT models (via the existing
`find_params_best()`/`get_param_grid()` path); rounds are still early-stopped.
`tune_grid = NULL` (default) is unchanged; ignored with a warning for non-BRT.

```r
grid <- expand.grid(max_depth = c(3, 4), eta = c(0.01, 0.02), gamma = 1,
                    colsample_bytree = 0.5, subsample = 0.5, min_child_weight = 10)
m <- train_frm(df, method = "brt", tune_grid = grid)
```

This is the user-facing home of the JCIM-benchmark result that FastRet's own
descriptors put through Retip's grid reproduce Retip-xgboost — i.e. the
from-scratch accuracy gap to Retip is grid-search effort, not descriptors.

## 2. Fix a GUI session crash on training data with an `INCHIKEY` column

`train_frm()` keeps `INCHIKEY` in `frm$df`, but the *Train* result handler
excluded only `NAME`/`RT`/`SMILES` before `round()`ing the descriptors, so the
character `INCHIKEY` column made `round()` error — and, running in a reactive
observer without a `tryCatch`, that error tore down the whole session. The
handler now rounds only the `CDFeatures` columns, and the extended-task status
observers are wrapped in `withShowError()` so any future handler error surfaces
as a notification instead of killing the session. (Surfaced by the 1.4.1 change
that deliberately keeps `INCHIKEY`.)

## 3. Notify the user which uploaded columns are dropped

Extra columns in an uploaded workbook (anything besides
`NAME`/`RT`/`SMILES`/`INCHIKEY`/`RT_ADJ` + descriptors) were removed silently.
`drop_unsupported_columns()` now records them and the upload handlers show a
notification naming the ignored columns. (Column *pass-through* — actually
carrying arbitrary user columns to the output — is a deliberate follow-up; see
the analysis in the task notes.)

## Notes
- Rebased onto `main` (v1.4.1); version bumped to **1.4.3** (1.4.2 = the
  `tune_grid` step) to avoid clashing with the 1.4.1 upload release.
- Tests added for `tune_grid` and the dropped-column tracking.
- Also makes `test-train_frm-gbtree.R` robust under `pkgload::load_all()`: the
  nw=1 vs nw=2 comparison previously tripped on the CV sub-models' `$version`
  field (parallel workers stamp the *installed* package version, not the
  checked-out one) during local dev; it is now normalised before the comparison,
  exactly as `nw` already was. It already passed under `R CMD check` (which
  installs the package first). Test-only change, no behaviour change.
