### PR TITLE
Point Measurements_v10P download at the example-data release (v1.5.1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: FastRet
 Title: Retention Time Prediction in Liquid Chromatography
-Version: 1.5.0
+Version: 1.5.1
 Authors@R: c(
     person(given = "Tobias", family = "Schmidt", role = c("aut", "cre", "cph"), email = "tobias.schmidt331@gmail.com", comment = c(ORCID = "0000-0001-9681-9253")),
     person(given = "Christian", family = "Amesoeder", role = c("aut", "cph"), email = "christian-amesoeder@web.de", comment = c(ORCID = "0000-0002-1668-8351")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,12 @@
 
+# FastRet 1.5.1
+
+- The descriptor-cache builder (`updateCachedCDs()`) and the example-data
+  generator (`misc/scripts/make-example-data.R`) now download
+  `Measurements_v10P.xlsx` from the version-independent `example-data` release tag
+  instead of the `v1.3.0` package release, so all example/source artifacts live in
+  one place and the build no longer pins an old package-version tag.
+
 # FastRet 1.5.0
 
 Example datasets & models refresh (see `issues/open/03_Update_Datasets.md`):

--- a/R/getcds.R
+++ b/R/getcds.R
@@ -235,7 +235,7 @@ assemble_cds <- function(uniq, have, newCDs) {
 updateCachedCDs <- function(nw = 1) {
     cols <- c("NAME", "SMILES", "RT")
     hilic <- read_retip_hilic_data()[, cols]
-    url <- "https://github.com/spang-lab/FastRet/releases/download/v1.3.0/Measurements_v10P.xlsx"
+    url <- "https://github.com/spang-lab/FastRet/releases/download/example-data/Measurements_v10P.xlsx"
     v10p_path <- tempfile("Measurements_v10P", fileext = ".xlsx")
     utils::download.file(url, v10p_path, mode = "wb")
     meas <- openxlsx::read.xlsx(v10p_path)[, cols] # all datasets, raw SMILES

--- a/misc/scripts/make-example-data.R
+++ b/misc/scripts/make-example-data.R
@@ -19,7 +19,7 @@ devtools::load_all(".")
 # CDs.sqlite instead of a possibly stale per-user copy.
 options(FastRet.cache_dir = file.path(tempdir(), "FastRet-make-example-cache"))
 
-url <- "https://github.com/spang-lab/FastRet/releases/download/v1.3.0/Measurements_v10P.xlsx"
+url <- "https://github.com/spang-lab/FastRet/releases/download/example-data/Measurements_v10P.xlsx"
 v10p_path <- tempfile("Measurements_v10P", fileext = ".xlsx")
 download.file(url, v10p_path, mode = "wb")
 X <- openxlsx::read.xlsx(v10p_path, 1)


### PR DESCRIPTION
## Summary

Follow-up to #15. `Measurements_v10P.xlsx` — the source table all shipped example data derives from — was still being downloaded from the **`v1.3.0`** package release. It is now **also published on the dedicated `example-data` release tag** (byte-identical; alongside `RP.xlsx`, `RP_adj.xlsx`, `RP_lasso_model.rds`), so this repoints both consumers to it:

- `R/getcds.R` → `updateCachedCDs()` (dev-only cache builder)
- `misc/scripts/make-example-data.R` (dev-only data generator)

This keeps all example/source artifacts in one stable place and stops the build from pinning an old *package-version* tag — the whole point of the version-independent `example-data` tag.

## Notes

- The **`v1.3.0` asset is intentionally kept** so the manuscript's existing data-availability link (`.../releases/download/v1.3.0/Measurements_v10P.xlsx`, referenced in `fastret-overleaf`) stays valid. The two copies are byte-identical (same SHA-256).
- Verified: `download.file()` from the `example-data` URL fetches the correct file (2044 rows, RP = 458).
- Version bumped 1.5.0 → **1.5.1** (required by the CI version-increment check; internal/dev-only change, no shipped behavior difference).

## Possible follow-up (separate, needs coordination)

The live manuscript (`fastret-overleaf/fastret.tex`, `fastret-marked.tex`) could also be repointed to the `example-data` URL for a permanent, version-independent data-availability link. That's a different repo under active JCIM revision, so I left it out here — happy to do it if wanted (leaving the frozen `submitted/` snapshots untouched).